### PR TITLE
Use b1.return_codes_ok in examples instead of b1ddi.return_codes_ok

### DIFF
--- a/documentation/source/b1ddi-usage.rst
+++ b/documentation/source/b1ddi-usage.rst
@@ -15,7 +15,7 @@ For BloxOne DDI therefore the basic usage structure for a *get* is::
     import bloxone
     b1ddi = bloxone.b1ddi(<cini file>)
     response = b1ddi.get(<object path>)
-    if response.status_code in b1ddi.return_codes_ok:
+    if response.status_code in b1.return_codes_ok:
         print(response.text)
     else: 
         print(response.status_code)
@@ -24,7 +24,7 @@ With create and update the key difference is that a JSON body is supplied::
 
     payload = '{ "address": "10.0.0.0", "cidr": "24" }'
     response = b1ddi.create('/ipam/subnet', body=payload)
-    if repsonse.status_code in b1ddi.return_codes_ok:
+    if repsonse.status_code in b1.return_codes_ok:
         print(repsonse.text)
     else: 
         print(response.status_code)

--- a/documentation/source/usage.rst
+++ b/documentation/source/usage.rst
@@ -103,7 +103,7 @@ Using BloxOne DDI as an example, the basic usage structure for a *get* is::
     import bloxone
     b1ddi = bloxone.b1ddi(<ini file>)
     response = b1ddi.get(<object path>)
-    if response.status_code in b1ddi.return_codes_ok:
+    if response.status_code in b1.return_codes_ok:
         print(response.text)
     else: 
         print(response.status_code)


### PR DESCRIPTION
I was originally using numeric HTML status codes (e.g., 200) in my
code, but decided to switch over to the style shown in the "Usage
and Examples" page. However referencing b1ddi.return_codes_ok gives
an error. I believe the reference should be to b1.return_codes_ok
instead. At least that works with my own code.